### PR TITLE
fix: preserve custom attributes name's case

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add the library to your project using Maven Central:
 <dependency>
     <groupId>com.newrelic.labs</groupId>
     <artifactId>custom-log4j2-appender</artifactId>
-    <version>1.1.10</version>
+    <version>1.1.12</version>
 </dependency>
 ```
 
@@ -38,7 +38,7 @@ Or, if using a locally built JAR file:
 <dependency>
     <groupId>com.newrelic.labs</groupId>
     <artifactId>custom-log4j2-appender</artifactId>
-    <version>1.1.10</version>
+    <version>1.1.12</version>
     <scope>system</scope>
     <systemPath>${project.basedir}/src/main/resources/custom-log4j2-appender.jar</systemPath>
 </dependency>

--- a/custom-log4j2-appender/build.gradle
+++ b/custom-log4j2-appender/build.gradle
@@ -27,7 +27,7 @@ shadowJar {
             'Implementation-Title': 'Custom Log4j2 Appender',
             'Implementation-Vendor': 'New Relic Labs',
             'Implementation-Vendor-Id': 'com.newrelic.labs',
-            'Implementation-Version': '1.1.4'
+            'Implementation-Version': '1.1.12'
         )
     }
 }
@@ -55,7 +55,7 @@ publishing {
 
             groupId = 'com.newrelic.labs'
             artifactId = 'custom-log4j2-appender'
-            version = '1.1.4'
+            version = '1.1.12'
 
             pom {
                 name = 'Custom Log4j2 Appender'

--- a/custom-log4j2-appender/pom.xml
+++ b/custom-log4j2-appender/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.newrelic.labs</groupId>
     <artifactId>custom-log4j2-appender</artifactId>
-    <version>1.1.10</version>
+    <version>1.1.12</version>
     <packaging>jar</packaging>
     <name>Custom Log4j2 Appender</name>
     <description>A custom Log4j2 appender for New Relic.</description>

--- a/custom-log4j2-appender/src/main/java/com/newrelic/labs/LogForwarder.java
+++ b/custom-log4j2-appender/src/main/java/com/newrelic/labs/LogForwarder.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -183,13 +184,15 @@ public class LogForwarder {
 		logEvent.put("applicationName", entry.getApplicationName());
 		logEvent.put("name", entry.getName());
 		logEvent.put("source", "NRBatchingAppender");
-		logEvent.put("version", "1.1.10");
+		logEvent.put("version", "1.1.12");
 
 		// Add custom fields
 		if (customFields != null) {
 			if (mergeCustomFields) {
-				for (Map.Entry<String, Object> field : customFields.entrySet()) { // Modify 1.1.0
-					logEvent.put(field.getKey(), field.getValue());
+				// Use putPreserveCase() to preserve custom field name casing
+				LowercaseKeyMap lowercaseMap = (LowercaseKeyMap) logEvent;
+				for (Map.Entry<String, Object> field : customFields.entrySet()) {
+					lowercaseMap.putPreserveCase(field.getKey(), field.getValue());
 				}
 			} else {
 				logEvent.put("custom", customFields);

--- a/custom-log4j2-appender/src/main/java/com/newrelic/labs/LowercaseKeyMap.java
+++ b/custom-log4j2-appender/src/main/java/com/newrelic/labs/LowercaseKeyMap.java
@@ -17,4 +17,12 @@ public class LowercaseKeyMap extends HashMap<String, Object> {
 	    this.put(entry.getKey().toLowerCase(), entry.getValue());
 	}
     }
+
+    /**
+     * Put a key-value pair without converting the key to lowercase.
+     * Use this for fields that should preserve their original case (e.g., custom fields).
+     */
+    public Object putPreserveCase(String key, Object value) {
+	return super.put(key, value);
+    }
 }

--- a/custom-log4j2-appender/src/main/java/com/newrelic/labs/NewRelicBatchingAppender.java
+++ b/custom-log4j2-appender/src/main/java/com/newrelic/labs/NewRelicBatchingAppender.java
@@ -159,7 +159,7 @@ public class NewRelicBatchingAppender extends AbstractAppender {
 			for (String pair : pairs) {
 				String[] keyValue = pair.split("=");
 				if (keyValue.length == 2) {
-					custom.put(keyValue[0], keyValue[1]);
+					custom.put(keyValue[0].trim(), keyValue[1].trim());
 				}
 			}
 		}


### PR DESCRIPTION
---
  Release Notes - Version 1.1.12

  Release Date: January 12, 2026

  Bug Fix

  Fixed: Custom field names now preserve case when mergeCustomFields=true

  Previously, custom field names like businessGroup and departmentName were converted to lowercase (businessgroup, departmentname) in New Relic.

  Before:
  businessgroup: "Sales"
  departmentname: "Finance"

  After:
  businessGroup: "Sales"
  departmentName: "Finance"

  Changes

  - Added putPreserveCase() method to LowercaseKeyMap
  - Updated custom field handling in LogForwarder
  - Added whitespace trimming to custom field parsing

  Upgrade

  <dependency>
      <groupId>com.newrelic.labs</groupId>
      <artifactId>custom-log4j2-appender</artifactId>
      <version>1.1.12</version>
  </dependency>

  Compatibility

  - ✅ Fully backward compatible with v1.1.10
  - ✅ No configuration changes required
  - ✅ Standard fields remain lowercase (hostname, logtype, etc.)

  ---
