### PR TITLE
Add preserveJsonKeys (and preservePayloadJson) to keep JSON attributes intact in New Relic, bump to 1.1.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add the library to your project using Maven Central:
 <dependency>
     <groupId>com.newrelic.labs</groupId>
     <artifactId>custom-log4j2-appender</artifactId>
-    <version>1.1.12</version>
+    <version>1.1.13</version>
 </dependency>
 ```
 
@@ -38,7 +38,7 @@ Or, if using a locally built JAR file:
 <dependency>
     <groupId>com.newrelic.labs</groupId>
     <artifactId>custom-log4j2-appender</artifactId>
-    <version>1.1.12</version>
+    <version>1.1.13</version>
     <scope>system</scope>
     <systemPath>${project.basedir}/src/main/resources/custom-log4j2-appender.jar</systemPath>
 </dependency>
@@ -110,6 +110,7 @@ Replace `[your-api-key]` with the ingest key obtained from the New Relic platfor
 | timeout             | No        | 30000                  | Connection timeout (in milliseconds) for HTTP requests                      |
 | obfuscationPatterns | No        |                        | Double caret (^^) separated RegEx patterns to obfuscate the matched pattern in the message. Refer to the example above for obfuscating credit card numbers and expiry dates                  |
 | unwrapJson          | No        | false                  | Controls JSON message processing behavior. When `false` (default), maintains original `message.x.y` structure. When `true`, unwraps JSON to flat attributes like `x.y` |
+| preservePayloadJson | No        | false                  | When `true`, if the log message is a JSON object containing a top-level `payload` key, that key's value is kept intact as a single attribute instead of being decomposed into `payload.<field>` sub-attributes by New Relic. See [Preserving payload JSON](#preserving-payload-json-v1113) below. |
 
 ---
 
@@ -166,6 +167,40 @@ JSON processing works with both Log4j2 layouts:
 **For new deployments**: Consider using `unwrapJson="true"` for cleaner attribute structure.
 
 **For existing deployments**: Keep `unwrapJson="false"` (default) to maintain existing dashboards and alerts that rely on `message.*` attributes.
+
+## Preserving Payload JSON [v1.1.13+]
+
+### The problem
+
+New Relic's Log API automatically parses any attribute value that is valid JSON text and flattens its fields into dot-notation sub-attributes (e.g. a nested `payload` object becomes `payload.messageId`, `payload.statusCode`, etc.). This happens at ingestion regardless of layout choice, and independently of any [Parsing Rule](#create-grok-parsing-rule-at-new-relic-platform) you may have configured — a Parsing Rule adds extracted attributes on top, it does not suppress New Relic's native JSON flattening.
+
+If your log message is a JSON object with a nested `payload` field that you want to keep intact — e.g. because it's a request/response body you want to query or copy as a single JSON document — this default flattening will break it apart.
+
+### The `preservePayloadJson` Parameter
+
+When `preservePayloadJson="true"` and `unwrapJson="true"`, the appender checks whether the (already-unwrapped) log message is a JSON object with a top-level key named `payload`. If found, that key's value is re-serialized and prefixed with a `##` marker before the whole message is sent — e.g.:
+
+```json
+"payload": "##{\"messageId\":\"...\",\"statusCode\":\"Success\",\"rooms\":[...]}"
+```
+
+The `##` prefix means the value no longer parses as valid JSON on its own, so New Relic leaves it as a single opaque string attribute instead of decomposing it. Every other field in the message (`sourceApp`, `correlationId`, etc.) is untouched and continues to flatten normally.
+
+```xml
+<NewRelicBatchingAppender name="NewRelicAppender"
+                          apiKey="YOUR_API_KEY"
+                          apiUrl="https://log-api.newrelic.com/log/v1"
+                          unwrapJson="true"
+                          preservePayloadJson="true">
+    <JsonLayout compact="true" eventEol="true"/>
+</NewRelicBatchingAppender>
+```
+
+**Recovering the original JSON:** consumers reading the `payload` attribute (NRQL, dashboards, scripts) need to strip the leading `##` before parsing it as JSON, e.g. `substring(payload, 2)`.
+
+**Requires `unwrapJson="true"`**: this feature inspects the message after it has already been unwrapped from the raw layout output; it has no effect if `unwrapJson` is `false` or the message has no top-level `payload` key.
+
+**Default is `false`**: existing deployments see no change in behavior unless this is explicitly enabled.
 
 ### Configuration Examples
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add the library to your project using Maven Central:
 <dependency>
     <groupId>com.newrelic.labs</groupId>
     <artifactId>custom-log4j2-appender</artifactId>
-    <version>1.1.13</version>
+    <version>1.1.14</version>
 </dependency>
 ```
 
@@ -38,7 +38,7 @@ Or, if using a locally built JAR file:
 <dependency>
     <groupId>com.newrelic.labs</groupId>
     <artifactId>custom-log4j2-appender</artifactId>
-    <version>1.1.13</version>
+    <version>1.1.14</version>
     <scope>system</scope>
     <systemPath>${project.basedir}/src/main/resources/custom-log4j2-appender.jar</systemPath>
 </dependency>
@@ -110,7 +110,8 @@ Replace `[your-api-key]` with the ingest key obtained from the New Relic platfor
 | timeout             | No        | 30000                  | Connection timeout (in milliseconds) for HTTP requests                      |
 | obfuscationPatterns | No        |                        | Double caret (^^) separated RegEx patterns to obfuscate the matched pattern in the message. Refer to the example above for obfuscating credit card numbers and expiry dates                  |
 | unwrapJson          | No        | false                  | Controls JSON message processing behavior. When `false` (default), maintains original `message.x.y` structure. When `true`, unwraps JSON to flat attributes like `x.y` |
-| preservePayloadJson | No        | false                  | When `true`, if the log message is a JSON object containing a top-level `payload` key, that key's value is kept intact as a single attribute instead of being decomposed into `payload.<field>` sub-attributes by New Relic. See [Preserving payload JSON](#preserving-payload-json-v1113) below. |
+| preservePayloadJson | No        | false                  | When `true`, keeps a top-level `payload` key intact as a single attribute instead of being decomposed into `payload.<field>` sub-attributes by New Relic. Shorthand for `preserveJsonKeys="payload"`. See [Preserving payload JSON](#preserving-payload-json-v1113) below. |
+| preserveJsonKeys    | No        |                        | Comma-separated list of top-level JSON key names (case-insensitive) to keep intact, in addition to `payload` if `preservePayloadJson="true"` is also set. E.g. `preserveJsonKeys="requestBody,responseData"`. See [Preserving payload JSON](#preserving-payload-json-v1113) below. |
 
 ---
 
@@ -168,7 +169,7 @@ JSON processing works with both Log4j2 layouts:
 
 **For existing deployments**: Keep `unwrapJson="false"` (default) to maintain existing dashboards and alerts that rely on `message.*` attributes.
 
-## Preserving Payload JSON [v1.1.13+]
+## Preserving Payload JSON [v1.1.14+]
 
 ### The problem
 
@@ -201,6 +202,25 @@ The `##` prefix means the value no longer parses as valid JSON on its own, so Ne
 **Requires `unwrapJson="true"`**: this feature inspects the message after it has already been unwrapped from the raw layout output; it has no effect if `unwrapJson` is `false` or the message has no top-level `payload` key.
 
 **Default is `false`**: existing deployments see no change in behavior unless this is explicitly enabled.
+
+### The `preserveJsonKeys` Parameter
+
+Not every Mule flow calls its request/response field `payload`, and some need more than one field protected. `preserveJsonKeys` generalizes the same mechanism to any set of top-level key names:
+
+```xml
+<NewRelicBatchingAppender name="NewRelicAppender"
+                          apiKey="YOUR_API_KEY"
+                          apiUrl="https://log-api.newrelic.com/log/v1"
+                          unwrapJson="true"
+                          preserveJsonKeys="requestBody,responseData">
+    <JsonLayout compact="true" eventEol="true"/>
+</NewRelicBatchingAppender>
+```
+
+- **Case-insensitive**: `preserveJsonKeys="requestbody"` matches a JSON field named `requestBody`, `RequestBody`, etc.
+- **Comma-separated**: list as many key names as needed; each is matched and protected independently.
+- **Combines with `preservePayloadJson`**: if both are set, the keys are unioned rather than one overriding the other — e.g. `preservePayloadJson="true" preserveJsonKeys="requestBody"` protects both `payload` and `requestBody`.
+- **Same mechanism as above**: each protected key's value gets the `##` marker treatment; strip it the same way before parsing the value back to JSON.
 
 ### Configuration Examples
 

--- a/custom-log4j2-appender/build.gradle
+++ b/custom-log4j2-appender/build.gradle
@@ -27,7 +27,7 @@ shadowJar {
             'Implementation-Title': 'Custom Log4j2 Appender',
             'Implementation-Vendor': 'New Relic Labs',
             'Implementation-Vendor-Id': 'com.newrelic.labs',
-            'Implementation-Version': '1.1.12'
+            'Implementation-Version': '1.1.13'
         )
     }
 }
@@ -55,7 +55,7 @@ publishing {
 
             groupId = 'com.newrelic.labs'
             artifactId = 'custom-log4j2-appender'
-            version = '1.1.12'
+            version = '1.1.13'
 
             pom {
                 name = 'Custom Log4j2 Appender'

--- a/custom-log4j2-appender/build.gradle
+++ b/custom-log4j2-appender/build.gradle
@@ -13,6 +13,13 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.1'
     implementation 'org.apache.logging.log4j:log4j-core:2.14.1'
     implementation 'org.apache.logging.log4j:log4j-api:2.14.1'
+
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.2'
+}
+
+test {
+    useJUnitPlatform()
 }
 
 jar {
@@ -27,7 +34,7 @@ shadowJar {
             'Implementation-Title': 'Custom Log4j2 Appender',
             'Implementation-Vendor': 'New Relic Labs',
             'Implementation-Vendor-Id': 'com.newrelic.labs',
-            'Implementation-Version': '1.1.13'
+            'Implementation-Version': '1.1.14'
         )
     }
 }
@@ -55,7 +62,7 @@ publishing {
 
             groupId = 'com.newrelic.labs'
             artifactId = 'custom-log4j2-appender'
-            version = '1.1.13'
+            version = '1.1.14'
 
             pom {
                 name = 'Custom Log4j2 Appender'

--- a/custom-log4j2-appender/pom.xml
+++ b/custom-log4j2-appender/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.newrelic.labs</groupId>
     <artifactId>custom-log4j2-appender</artifactId>
-    <version>1.1.12</version>
+    <version>1.1.13</version>
     <packaging>jar</packaging>
     <name>Custom Log4j2 Appender</name>
     <description>A custom Log4j2 appender for New Relic.</description>

--- a/custom-log4j2-appender/pom.xml
+++ b/custom-log4j2-appender/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.newrelic.labs</groupId>
     <artifactId>custom-log4j2-appender</artifactId>
-    <version>1.1.13</version>
+    <version>1.1.14</version>
     <packaging>jar</packaging>
     <name>Custom Log4j2 Appender</name>
     <description>A custom Log4j2 appender for New Relic.</description>
@@ -19,6 +19,7 @@
         <okhttp.version>4.9.3</okhttp.version>
         <jackson.version>2.13.1</jackson.version>
         <log4j.version>2.14.1</log4j.version>
+        <junit.version>5.10.2</junit.version>
     </properties>
 
     <build>
@@ -34,6 +35,12 @@
                 </configuration>
             </plugin>
             
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
@@ -137,6 +144,12 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
             <version>${log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/custom-log4j2-appender/src/main/java/com/newrelic/labs/LogForwarder.java
+++ b/custom-log4j2-appender/src/main/java/com/newrelic/labs/LogForwarder.java
@@ -184,7 +184,7 @@ public class LogForwarder {
 		logEvent.put("applicationName", entry.getApplicationName());
 		logEvent.put("name", entry.getName());
 		logEvent.put("source", "NRBatchingAppender");
-		logEvent.put("version", "1.1.12");
+		logEvent.put("version", "1.1.13");
 
 		// Add custom fields
 		if (customFields != null) {

--- a/custom-log4j2-appender/src/main/java/com/newrelic/labs/LogForwarder.java
+++ b/custom-log4j2-appender/src/main/java/com/newrelic/labs/LogForwarder.java
@@ -184,7 +184,7 @@ public class LogForwarder {
 		logEvent.put("applicationName", entry.getApplicationName());
 		logEvent.put("name", entry.getName());
 		logEvent.put("source", "NRBatchingAppender");
-		logEvent.put("version", "1.1.13");
+		logEvent.put("version", "1.1.14");
 
 		// Add custom fields
 		if (customFields != null) {

--- a/custom-log4j2-appender/src/main/java/com/newrelic/labs/NewRelicBatchingAppender.java
+++ b/custom-log4j2-appender/src/main/java/com/newrelic/labs/NewRelicBatchingAppender.java
@@ -39,6 +39,7 @@ public class NewRelicBatchingAppender extends AbstractAppender {
 	private final String name;
 	private final String obfuscationPatterns;
 	private final boolean unwrapJson; // 1.1.10 - Flag to control JSON unwrapping behavior (true = unwrap to x.y, false = keep message.x.y)
+	private final boolean preservePayloadJson; // Opt-in: keep a top-level "payload" key in the message JSON intact so New Relic does not decompose it into payload.<field> attributes
 	private final LogForwarder logForwarder;
 	private static final Logger logger = StatusLogger.getLogger();
 	private int attempt = 0; // Track attempts across harvest cycles
@@ -61,13 +62,14 @@ public class NewRelicBatchingAppender extends AbstractAppender {
 	// for custom fields i.e. custom.attribute1
 	private static final long DEFAULT_MAX_QUEUE_SIZE_BYTES = 2097152; // 2 MB // 1.1.0
 	private static final boolean DEFAULT_UNWRAP_JSON = false; // 1.1.10 - Default to original behavior (unwrapJson=false means keep message.x.y)
+	private static final boolean DEFAULT_PRESERVE_PAYLOAD_JSON = false; // Default off - preserves existing behavior for current customers
 	private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1); // 1.1.0
 
 	protected NewRelicBatchingAppender(String name, Filter filter, Layout<? extends Serializable> layout,
 			final boolean ignoreExceptions, String apiKey, String apiUrl, String applicationName, Integer batchSize,
 			Long maxMessageSize, Long flushInterval, Long queueCapacity, String logType, String customFields,
 			Boolean mergeCustomFields, int maxRetries, long timeout, Integer connPoolSize, String obfuscationPatterns,
-			Boolean unwrapJson) {
+			Boolean unwrapJson, Boolean preservePayloadJson) {
 		super(name, filter, layout, ignoreExceptions, Property.EMPTY_ARRAY);
 
 		this.queueCapacity = queueCapacity != null && queueCapacity > 0 ? queueCapacity : DEFAULT_MAX_QUEUE_SIZE_BYTES;
@@ -148,7 +150,8 @@ public class NewRelicBatchingAppender extends AbstractAppender {
 		this.obfuscationPatterns = obfuscationPatterns;
 		// unwrapJson=true means unwrap JSON to x.y, unwrapJson=false means keep message.x.y (original behavior)
 		this.unwrapJson = unwrapJson != null ? unwrapJson : DEFAULT_UNWRAP_JSON;
-		
+		this.preservePayloadJson = preservePayloadJson != null ? preservePayloadJson : DEFAULT_PRESERVE_PAYLOAD_JSON;
+
 		startFlushingTask();
 	}
 
@@ -222,6 +225,33 @@ public class NewRelicBatchingAppender extends AbstractAppender {
 		return message;
 	}
 
+	private static final String PAYLOAD_MARKER = "##";
+
+	/**
+	 * If message is a JSON object with a top-level "payload" key, break that key's value out of
+	 * JSON syntax (by prefixing it) so New Relic's automatic JSON-string parsing leaves it as a
+	 * single opaque attribute instead of decomposing it into payload.<field> sub-attributes.
+	 * Everything else in message is returned unchanged.
+	 */
+	private String neutralizePayloadJson(String message) {
+		if (message == null || !message.trim().startsWith("{")) {
+			return message;
+		}
+		try {
+			com.fasterxml.jackson.databind.ObjectMapper mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+			com.fasterxml.jackson.databind.JsonNode root = mapper.readTree(message);
+			if (root == null || !root.isObject() || !root.has("payload")) {
+				return message;
+			}
+			String payloadJson = mapper.writeValueAsString(root.get("payload"));
+			((com.fasterxml.jackson.databind.node.ObjectNode) root).put("payload", PAYLOAD_MARKER + payloadJson);
+			return mapper.writeValueAsString(root);
+		} catch (Exception e) {
+			// Not valid JSON, or no "payload" key - leave message untouched
+			return message;
+		}
+	}
+
 	@PluginFactory
 	public static NewRelicBatchingAppender createAppender(@PluginAttribute("name") String name,
 			@PluginElement("Layout") Layout<? extends Serializable> layout,
@@ -236,7 +266,8 @@ public class NewRelicBatchingAppender extends AbstractAppender {
 			@PluginAttribute(value = "maxRetries") Integer maxRetries, @PluginAttribute(value = "timeout") Long timeout,
 			@PluginAttribute(value = "connPoolSize") Integer connPoolSize,
 			@PluginAttribute(value = "obfuscationPatterns") String obfuscationPatterns,
-			@PluginAttribute(value = "unwrapJson") String unwrapJson) {
+			@PluginAttribute(value = "unwrapJson") String unwrapJson,
+			@PluginAttribute(value = "preservePayloadJson") Boolean preservePayloadJson) {
 
 		if (name == null) {
 			logger.error("No name provided for NewRelicBatchingAppender");
@@ -263,7 +294,7 @@ public class NewRelicBatchingAppender extends AbstractAppender {
 		
 		return new NewRelicBatchingAppender(name, filter, layout, true, apiKey, apiUrl, applicationName, batchSize,
 				maxMessageSize, flushInterval, queueCapacity, logType, customFields, mergeCustomFields, retries,
-				connectionTimeout, connPoolSize, obfuscationPatterns, unwrapJsonBool);
+				connectionTimeout, connPoolSize, obfuscationPatterns, unwrapJsonBool, preservePayloadJson);
 	}
 
 	public void appendOld(LogEvent event) {
@@ -380,7 +411,15 @@ public class NewRelicBatchingAppender extends AbstractAppender {
 			}
 		}
 		// End: Configurable JSON message processing
-		
+
+		// Opt-in (preservePayloadJson="true"): if the (now-unwrapped) message is itself a JSON
+		// object containing a "payload" key, break that key's value out of JSON syntax so New
+		// Relic's automatic JSON-string parsing does not decompose it into payload.<field>
+		// attributes. Everything else in the message is left untouched and still auto-flattens.
+		if (preservePayloadJson && message != null) {
+			message = neutralizePayloadJson(message);
+		}
+
 		String loggerName = event.getLoggerName();
 		String logLevel = event.getLevel().name();
 		long timestamp = event.getTimeMillis(); // Capture the log creation timestamp

--- a/custom-log4j2-appender/src/main/java/com/newrelic/labs/NewRelicBatchingAppender.java
+++ b/custom-log4j2-appender/src/main/java/com/newrelic/labs/NewRelicBatchingAppender.java
@@ -3,8 +3,10 @@ package com.newrelic.labs;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -39,7 +41,10 @@ public class NewRelicBatchingAppender extends AbstractAppender {
 	private final String name;
 	private final String obfuscationPatterns;
 	private final boolean unwrapJson; // 1.1.10 - Flag to control JSON unwrapping behavior (true = unwrap to x.y, false = keep message.x.y)
-	private final boolean preservePayloadJson; // Opt-in: keep a top-level "payload" key in the message JSON intact so New Relic does not decompose it into payload.<field> attributes
+	// Opt-in: lowercased top-level key names to keep intact in the message JSON so New Relic does not
+	// decompose their values into <key>.<field> attributes. Empty set = feature off (default).
+	// Populated from preservePayloadJson (implies "payload") unioned with preserveJsonKeys.
+	private final Set<String> preserveJsonKeys;
 	private final LogForwarder logForwarder;
 	private static final Logger logger = StatusLogger.getLogger();
 	private int attempt = 0; // Track attempts across harvest cycles
@@ -62,14 +67,14 @@ public class NewRelicBatchingAppender extends AbstractAppender {
 	// for custom fields i.e. custom.attribute1
 	private static final long DEFAULT_MAX_QUEUE_SIZE_BYTES = 2097152; // 2 MB // 1.1.0
 	private static final boolean DEFAULT_UNWRAP_JSON = false; // 1.1.10 - Default to original behavior (unwrapJson=false means keep message.x.y)
-	private static final boolean DEFAULT_PRESERVE_PAYLOAD_JSON = false; // Default off - preserves existing behavior for current customers
+	private static final String DEFAULT_PRESERVE_PAYLOAD_KEY = "payload"; // implied key when preservePayloadJson="true"
 	private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1); // 1.1.0
 
 	protected NewRelicBatchingAppender(String name, Filter filter, Layout<? extends Serializable> layout,
 			final boolean ignoreExceptions, String apiKey, String apiUrl, String applicationName, Integer batchSize,
 			Long maxMessageSize, Long flushInterval, Long queueCapacity, String logType, String customFields,
 			Boolean mergeCustomFields, int maxRetries, long timeout, Integer connPoolSize, String obfuscationPatterns,
-			Boolean unwrapJson, Boolean preservePayloadJson) {
+			Boolean unwrapJson, Boolean preservePayloadJson, String preserveJsonKeys) {
 		super(name, filter, layout, ignoreExceptions, Property.EMPTY_ARRAY);
 
 		this.queueCapacity = queueCapacity != null && queueCapacity > 0 ? queueCapacity : DEFAULT_MAX_QUEUE_SIZE_BYTES;
@@ -150,7 +155,7 @@ public class NewRelicBatchingAppender extends AbstractAppender {
 		this.obfuscationPatterns = obfuscationPatterns;
 		// unwrapJson=true means unwrap JSON to x.y, unwrapJson=false means keep message.x.y (original behavior)
 		this.unwrapJson = unwrapJson != null ? unwrapJson : DEFAULT_UNWRAP_JSON;
-		this.preservePayloadJson = preservePayloadJson != null ? preservePayloadJson : DEFAULT_PRESERVE_PAYLOAD_JSON;
+		this.preserveJsonKeys = resolvePreserveJsonKeys(preservePayloadJson, preserveJsonKeys);
 
 		startFlushingTask();
 	}
@@ -225,29 +230,73 @@ public class NewRelicBatchingAppender extends AbstractAppender {
 		return message;
 	}
 
-	private static final String PAYLOAD_MARKER = "##";
+	private static final String PROTECTED_JSON_MARKER = "##";
 
 	/**
-	 * If message is a JSON object with a top-level "payload" key, break that key's value out of
-	 * JSON syntax (by prefixing it) so New Relic's automatic JSON-string parsing leaves it as a
-	 * single opaque attribute instead of decomposing it into payload.<field> sub-attributes.
-	 * Everything else in message is returned unchanged.
+	 * Resolves the final, lowercased set of top-level JSON keys to protect from New Relic's
+	 * automatic JSON-string flattening: preservePayloadJson="true" implies "payload", and
+	 * preserveJsonKeys (comma-separated) is unioned on top of that. Matching is case-insensitive,
+	 * consistent with LowercaseKeyMap's handling of other attribute names in this appender.
 	 */
-	private String neutralizePayloadJson(String message) {
-		if (message == null || !message.trim().startsWith("{")) {
+	static Set<String> resolvePreserveJsonKeys(Boolean preservePayloadJson, String preserveJsonKeysCsv) {
+		Set<String> keys = new HashSet<>();
+		if (preservePayloadJson != null && preservePayloadJson) {
+			keys.add(DEFAULT_PRESERVE_PAYLOAD_KEY);
+		}
+		if (preserveJsonKeysCsv != null && !preserveJsonKeysCsv.trim().isEmpty()) {
+			for (String key : preserveJsonKeysCsv.split(",")) {
+				String trimmed = key.trim().toLowerCase();
+				if (!trimmed.isEmpty()) {
+					keys.add(trimmed);
+				}
+			}
+		}
+		return keys;
+	}
+
+	/**
+	 * If message is a JSON object with any top-level key whose name matches keysLower
+	 * (case-insensitively), break that key's value out of JSON syntax (by prefixing it) so New
+	 * Relic's automatic JSON-string parsing leaves it as a single opaque attribute instead of
+	 * decomposing it into <key>.<field> sub-attributes. Every other key is returned unchanged.
+	 */
+	static String neutralizeJsonKeys(String message, Set<String> keysLower) {
+		if (message == null || keysLower == null || keysLower.isEmpty() || !message.trim().startsWith("{")) {
 			return message;
 		}
 		try {
 			com.fasterxml.jackson.databind.ObjectMapper mapper = new com.fasterxml.jackson.databind.ObjectMapper();
 			com.fasterxml.jackson.databind.JsonNode root = mapper.readTree(message);
-			if (root == null || !root.isObject() || !root.has("payload")) {
+			if (root == null || !root.isObject()) {
 				return message;
 			}
-			String payloadJson = mapper.writeValueAsString(root.get("payload"));
-			((com.fasterxml.jackson.databind.node.ObjectNode) root).put("payload", PAYLOAD_MARKER + payloadJson);
-			return mapper.writeValueAsString(root);
+			com.fasterxml.jackson.databind.node.ObjectNode objectRoot = (com.fasterxml.jackson.databind.node.ObjectNode) root;
+
+			// Collect matching field names first - mutating the object while its fieldNames()
+			// iterator is in progress would throw ConcurrentModificationException.
+			List<String> matchedFields = new ArrayList<>();
+			java.util.Iterator<String> fieldNames = objectRoot.fieldNames();
+			while (fieldNames.hasNext()) {
+				String fieldName = fieldNames.next();
+				if (keysLower.contains(fieldName.toLowerCase())) {
+					matchedFields.add(fieldName);
+				}
+			}
+			if (matchedFields.isEmpty()) {
+				return message;
+			}
+
+			for (String fieldName : matchedFields) {
+				com.fasterxml.jackson.databind.JsonNode valueNode = objectRoot.get(fieldName);
+				// If the value is already a JSON string (e.g. the source flow pre-serialized it),
+				// use its text as-is; re-serializing it with writeValueAsString would double-encode
+				// it. Otherwise (a live object/array node) serialize it to its own compact JSON text.
+				String valueJson = valueNode.isTextual() ? valueNode.asText() : mapper.writeValueAsString(valueNode);
+				objectRoot.put(fieldName, PROTECTED_JSON_MARKER + valueJson);
+			}
+			return mapper.writeValueAsString(objectRoot);
 		} catch (Exception e) {
-			// Not valid JSON, or no "payload" key - leave message untouched
+			// Not valid JSON - leave message untouched
 			return message;
 		}
 	}
@@ -267,7 +316,8 @@ public class NewRelicBatchingAppender extends AbstractAppender {
 			@PluginAttribute(value = "connPoolSize") Integer connPoolSize,
 			@PluginAttribute(value = "obfuscationPatterns") String obfuscationPatterns,
 			@PluginAttribute(value = "unwrapJson") String unwrapJson,
-			@PluginAttribute(value = "preservePayloadJson") Boolean preservePayloadJson) {
+			@PluginAttribute(value = "preservePayloadJson") Boolean preservePayloadJson,
+			@PluginAttribute(value = "preserveJsonKeys") String preserveJsonKeys) {
 
 		if (name == null) {
 			logger.error("No name provided for NewRelicBatchingAppender");
@@ -294,7 +344,8 @@ public class NewRelicBatchingAppender extends AbstractAppender {
 		
 		return new NewRelicBatchingAppender(name, filter, layout, true, apiKey, apiUrl, applicationName, batchSize,
 				maxMessageSize, flushInterval, queueCapacity, logType, customFields, mergeCustomFields, retries,
-				connectionTimeout, connPoolSize, obfuscationPatterns, unwrapJsonBool, preservePayloadJson);
+				connectionTimeout, connPoolSize, obfuscationPatterns, unwrapJsonBool, preservePayloadJson,
+				preserveJsonKeys);
 	}
 
 	public void appendOld(LogEvent event) {
@@ -412,12 +463,12 @@ public class NewRelicBatchingAppender extends AbstractAppender {
 		}
 		// End: Configurable JSON message processing
 
-		// Opt-in (preservePayloadJson="true"): if the (now-unwrapped) message is itself a JSON
-		// object containing a "payload" key, break that key's value out of JSON syntax so New
-		// Relic's automatic JSON-string parsing does not decompose it into payload.<field>
-		// attributes. Everything else in the message is left untouched and still auto-flattens.
-		if (preservePayloadJson && message != null) {
-			message = neutralizePayloadJson(message);
+		// Opt-in (preservePayloadJson and/or preserveJsonKeys): if the (now-unwrapped) message is
+		// itself a JSON object containing one of the configured keys, break that key's value out
+		// of JSON syntax so New Relic's automatic JSON-string parsing does not decompose it into
+		// <key>.<field> attributes. Every other key is left untouched and still auto-flattens.
+		if (!preserveJsonKeys.isEmpty() && message != null) {
+			message = neutralizeJsonKeys(message, preserveJsonKeys);
 		}
 
 		String loggerName = event.getLoggerName();

--- a/custom-log4j2-appender/src/test/java/com/newrelic/labs/NewRelicBatchingAppenderTest.java
+++ b/custom-log4j2-appender/src/test/java/com/newrelic/labs/NewRelicBatchingAppenderTest.java
@@ -1,0 +1,166 @@
+package com.newrelic.labs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Collections;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers neutralizeJsonKeys and resolvePreserveJsonKeys, which back the preservePayloadJson and
+ * preserveJsonKeys appender attributes. The two "payload"-shaped inputs below correspond to two
+ * real, distinct Mule flow conventions observed in practice: one embeds "payload" as a live
+ * nested JSON object, the other embeds it as an already-serialized JSON string (with its own
+ * escaped whitespace/newlines).
+ */
+class NewRelicBatchingAppenderTest {
+
+	private static final ObjectMapper MAPPER = new ObjectMapper();
+	private static final String MARKER = "##";
+	private static final Set<String> PAYLOAD_KEY = Collections.singleton("payload");
+
+	@Test
+	void payloadAsLiveObject_isMarkedButStaysCompactAndValid() throws Exception {
+		String message = "{\"correlationId\":\"abc-123\",\"sourceApp\":\"ODX App\","
+				+ "\"payload\":{\"messageId\":\"f56f7330\",\"statusCode\":\"Success\","
+				+ "\"rooms\":[{\"roomId\":\"180\",\"roomNumber\":\"0908\"}]}}";
+
+		String result = NewRelicBatchingAppender.neutralizeJsonKeys(message, PAYLOAD_KEY);
+
+		JsonNode root = MAPPER.readTree(result); // whole message must still be valid JSON
+		assertEquals("abc-123", root.get("correlationId").asText());
+		assertEquals("ODX App", root.get("sourceApp").asText());
+
+		String payloadValue = root.get("payload").asText();
+		assertTrue(payloadValue.startsWith(MARKER), "payload value should be marker-prefixed: " + payloadValue);
+
+		String stripped = payloadValue.substring(MARKER.length());
+		assertTrue(isValidJson(stripped), "stripped payload should parse back to the original JSON");
+		JsonNode recoveredPayload = MAPPER.readTree(stripped);
+		assertEquals("f56f7330", recoveredPayload.get("messageId").asText());
+		assertEquals("Success", recoveredPayload.get("statusCode").asText());
+
+		// No stray extra quoting/escaping: exactly one JSON-encode round trip, not two.
+		assertFalse(stripped.startsWith("\""), "payload text should not be double-encoded: " + payloadValue);
+	}
+
+	@Test
+	void payloadAsPreStringifiedJson_isMarkedWithoutDoubleEncoding() throws Exception {
+		// Mirrors the real customer case: DataWeave wrote payload as a pretty-printed JSON
+		// *string* (embedded literal newlines), not a live nested object.
+		String prettyPayloadJson = "{\n  \"messageId\": \"f56f7330\",\n  \"statusCode\": \"Success\"\n}";
+		String messageWithStringPayload = "{\"correlationId\":\"abc-123\",\"payload\":"
+				+ MAPPER.writeValueAsString(prettyPayloadJson) + "}";
+
+		String result = NewRelicBatchingAppender.neutralizeJsonKeys(messageWithStringPayload, PAYLOAD_KEY);
+
+		JsonNode root = MAPPER.readTree(result);
+		String payloadValue = root.get("payload").asText();
+		assertTrue(payloadValue.startsWith(MARKER), "payload value should be marker-prefixed: " + payloadValue);
+
+		String stripped = payloadValue.substring(MARKER.length());
+
+		// This is the regression this test guards against: a double-encoded value looks like
+		// ##"{\n  \"messageId\": ...  (an extra leading quote, escaped newlines preserved as
+		// literal backslash-n) instead of the clean, once-encoded original text.
+		assertFalse(stripped.startsWith("\""),
+				"payload was double-encoded - got: " + payloadValue);
+
+		JsonNode recoveredPayload = MAPPER.readTree(stripped);
+		assertEquals("f56f7330", recoveredPayload.get("messageId").asText());
+		assertEquals("Success", recoveredPayload.get("statusCode").asText());
+	}
+
+	@Test
+	void caseInsensitiveKeyMatch_matchesDifferentCasing() throws Exception {
+		// Configured key is lowercase "payload", but the actual JSON field is "Payload".
+		String message = "{\"correlationId\":\"abc-123\",\"Payload\":{\"messageId\":\"f56f7330\"}}";
+
+		String result = NewRelicBatchingAppender.neutralizeJsonKeys(message, PAYLOAD_KEY);
+
+		JsonNode root = MAPPER.readTree(result);
+		String payloadValue = root.get("Payload").asText();
+		assertTrue(payloadValue.startsWith(MARKER), "differently-cased key should still be matched: " + payloadValue);
+	}
+
+	@Test
+	void multipleConfiguredKeys_areProtected_othersStillFlatten() throws Exception {
+		String message = "{\"correlationId\":\"abc-123\",\"sourceApp\":\"ODX App\","
+				+ "\"payload\":{\"a\":1},\"requestBody\":{\"b\":2}}";
+		Set<String> keys = new java.util.HashSet<>(java.util.Arrays.asList("payload", "requestbody"));
+
+		String result = NewRelicBatchingAppender.neutralizeJsonKeys(message, keys);
+
+		JsonNode root = MAPPER.readTree(result);
+		assertTrue(root.get("payload").asText().startsWith(MARKER));
+		assertTrue(root.get("requestBody").asText().startsWith(MARKER));
+		// sourceApp was never a target key - stays a plain, untouched string value.
+		assertEquals("ODX App", root.get("sourceApp").asText());
+	}
+
+	@Test
+	void emptyKeysSet_returnsMessageUnchanged() {
+		String message = "{\"payload\":{\"a\":1}}";
+		assertEquals(message, NewRelicBatchingAppender.neutralizeJsonKeys(message, Collections.emptySet()));
+	}
+
+	@Test
+	void messageWithoutMatchingKey_isReturnedUnchanged() {
+		String message = "{\"correlationId\":\"abc-123\",\"sourceApp\":\"ODX App\"}";
+		assertEquals(message, NewRelicBatchingAppender.neutralizeJsonKeys(message, PAYLOAD_KEY));
+	}
+
+	@Test
+	void nonJsonMessage_isReturnedUnchanged() {
+		String message = "plain text log line, not JSON";
+		assertEquals(message, NewRelicBatchingAppender.neutralizeJsonKeys(message, PAYLOAD_KEY));
+	}
+
+	@Test
+	void nullMessage_isReturnedUnchanged() {
+		assertEquals(null, NewRelicBatchingAppender.neutralizeJsonKeys(null, PAYLOAD_KEY));
+	}
+
+	@Test
+	void resolvePreserveJsonKeys_payloadFlagOnly_impliesPayload() {
+		Set<String> keys = NewRelicBatchingAppender.resolvePreserveJsonKeys(true, null);
+		assertEquals(Collections.singleton("payload"), keys);
+	}
+
+	@Test
+	void resolvePreserveJsonKeys_csvOnly_returnsLowercasedTrimmedKeys() {
+		Set<String> keys = NewRelicBatchingAppender.resolvePreserveJsonKeys(false, " RequestBody , ResponseData ");
+		assertEquals(new java.util.HashSet<>(java.util.Arrays.asList("requestbody", "responsedata")), keys);
+	}
+
+	@Test
+	void resolvePreserveJsonKeys_bothSet_unionsRatherThanOverrides() {
+		Set<String> keys = NewRelicBatchingAppender.resolvePreserveJsonKeys(true, "requestBody");
+		assertEquals(new java.util.HashSet<>(java.util.Arrays.asList("payload", "requestbody")), keys);
+	}
+
+	@Test
+	void resolvePreserveJsonKeys_neitherSet_returnsEmptySet() {
+		Set<String> keys = NewRelicBatchingAppender.resolvePreserveJsonKeys(null, null);
+		assertTrue(keys.isEmpty());
+	}
+
+	@Test
+	void resolvePreserveJsonKeys_csvWithBlankEntries_ignoresThem() {
+		Set<String> keys = NewRelicBatchingAppender.resolvePreserveJsonKeys(false, "payload,,  ,requestBody");
+		assertEquals(new java.util.HashSet<>(java.util.Arrays.asList("payload", "requestbody")), keys);
+	}
+
+	private static boolean isValidJson(String text) {
+		try {
+			MAPPER.readTree(text);
+			return true;
+		} catch (Exception e) {
+			return false;
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- New Relic's Log API automatically flattens any JSON-valued attribute into dot-notation sub-attributes, with no per-attribute opt-out available today (confirmed against docs.newrelic.com and via internal Logging team feedback).
- Adds an opt-in appender attribute, `preservePayloadJson` (default `false`, no effect on existing customers), that breaks a top-level `payload` key in the message JSON out of JSON syntax with a `##` marker before sending, so New Relic leaves it as a single intact attribute while everything else in the message still flattens normally.
- **Fix (this iteration):** the initial version double-encoded `payload` when its value was already a JSON *string* (some Mule flows pre-serialize via DataWeave `write()`) rather than a live nested object, producing a broken `##"{\n ...` value instead of a clean `##{...}`. Found against a real customer account, reproduced deterministically in a new test, and fixed by checking `isTextual()` before deciding whether to re-serialize.
- **Generalized (this iteration):** added `preserveJsonKeys` (comma-separated, case-insensitive) so customers whose field isn't literally named `payload` — or who need multiple fields protected — can opt in without a payload-specific flag. `preservePayloadJson` and `preserveJsonKeys` union rather than override when both are set.
- Added JUnit 5 test infrastructure (there was none) to both `build.gradle` and `pom.xml`, plus a 13-test regression suite covering both payload shapes, case-insensitive matching, multi-key protection, and the union-resolution logic.
- Bumps version to 1.1.14 

## Usage
```xml
<NewRelicBatchingAppender name="NewRelicAppender"
                          apiKey="YOUR_API_KEY"
                          apiUrl="https://log-api.newrelic.com/log/v1"
                          unwrapJson="true"
                          preservePayloadJson="true"
                          preserveJsonKeys="requestBody,responseData">
    <JsonLayout compact="true" eventEol="true"/>
</NewRelicBatchingAppender>
```
Requires `unwrapJson="true"`. Consumers reading a protected key's value downstream need to strip the leading `##` before parsing it back to JSON.

## Test plan
- [x] Compiles under JDK 8 (Gradle and Maven)
- [x] `./gradlew :custom-log4j2-appender:test` and `mvn test` both pass (13/13)
- [x] New regression test reproduces the double-encoding bug against the pre-fix code, and passes after the fix
- [x] Validated live against a customer New Relic account: payload preserved as one attribute, other fields (correlationId, sourceApp, etc.) still flatten as before
- [x] Validated live against the actual pre-stringified-payload shape that caused the double-encoding bug, after updating the sample Mule app to reproduce it
